### PR TITLE
fix: Use new OCM capabilities API

### DIFF
--- a/integration_jupyterhub/lib/Federation/WebappCapabilityDiscovery.php
+++ b/integration_jupyterhub/lib/Federation/WebappCapabilityDiscovery.php
@@ -126,7 +126,7 @@ class WebappCapabilityDiscovery
     if (!$provider->isEnabled()) {
       return false;
     }
-    return in_array('exchange-token', $provider->getCapabilities(), true)
+    return $provider->getCapabilities()->hasExchangeToken()
       && $provider->getTokenEndPoint() !== '';
   }
 


### PR DESCRIPTION
After the changes from the last review `getCapabilities` returns an `OCMCapabilities` object rather than an array